### PR TITLE
migrate to werkers docker stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OS Grid Converter
 
+[![wercker status](https://app.wercker.com/status/f84eb5310b57ee9d6acc3501763fdb75/s/master "wercker status")](https://app.wercker.com/project/byKey/f84eb5310b57ee9d6acc3501763fdb75)
+
 A Go library that provides utilities to convert Ordnance Survey Grid references to Latitude and Longitude.
 
 ## Credits

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: wercker/golang
+box: golang:1.7.4
 # Build definition
 build:
   steps:
@@ -10,4 +10,4 @@ build:
     - script:
         name: go test
         code: |
-          go test
+          go test ./...


### PR DESCRIPTION
This PR migrates the to the new werker stack 

For evidence this works correctly see -

https://app.wercker.com/Thingful/osgridconverter/runs